### PR TITLE
Change all python-intro. links to python.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -123,7 +123,7 @@ Hosted with <a href="https://aws.amazon.com/">Amazon Web Services</a>.</p>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
         <script>window.jQuery || document.write('<script src="/assets/js/jquery-1.11.0.min.js"><\/script>')</script>
 
-        <script src="https://assets.quantecon.org/js/menubar-20200503-3.js"></script>
+        <script src="https://assets.quantecon.org/js/menubar-20200503-4.js"></script>
         <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
         <script src="{{ '/assets/js/prism.js' | relative_url }}"></script>
         <script type="text/x-mathjax-config">

--- a/_posts/2020-04-07-python-lecture-split.md
+++ b/_posts/2020-04-07-python-lecture-split.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Python Lecture Series Split"
+title: 'Python Lecture Series Split'
 author: QuantEcon
 excerpt: Python Lecture Series Split
 ---
@@ -9,6 +9,6 @@ QuantEcon has divided its [main Python lecture series](https://python.quantecon.
 
 The first series is called [Python Programming for Quantitative Economics](https://python-programming.quantecon.org/). These lectures teach Python from basics and foundations to advanced, high-performance features, including just-in-time compilation and parallelization.
 
-The second series is called [Introductory Quantitative Economics with Python](https://python-intro.quantecon.org/). This part covers solving and simulating fundamental economic models using Python and a range of modern algorithms. It is suited to advanced undergraduates and first year graduate students.
+The second series is called [Introductory Quantitative Economics with Python](https://python.quantecon.org/). This part covers solving and simulating fundamental economic models using Python and a range of modern algorithms. It is suited to advanced undergraduates and first year graduate students.
 
 The third series is [Advanced Quantitative Economics with Python](https://python-advanced.quantecon.org/). This series builds on the introductory lectures and is suited to a graduate students and practitioners.

--- a/pages/about-python-lectures.md
+++ b/pages/about-python-lectures.md
@@ -11,7 +11,7 @@ menu_item: false
 This page collects three lecture series:
 
 1. [Python Programming for Economics and Finance](https://python-programming.quantecon.org/)
-2. [Quantitative Economics with Python](https://python-intro.quantecon.org/) and
+2. [Quantitative Economics with Python](https://python.quantecon.org/) and
 3. [Advanced Quantitative Economics with Python](https://python-advanced.quantecon.org/)
 
 Previously all three were combined in a single site but as the number of
@@ -106,10 +106,10 @@ We also recognize those who co-authored lectures and code:
 
 - Co-authored [Additive and Multiplicative Functionals](https://python-advanced.quantecon.org/additive_functionals.html)
 - Co-authored [Globalization and Cycles](https://python-advanced.quantecon.org/matsuyama.html)
-- Co-authored [Permanent Income II: LQ Techniques](https://python-intro.quantecon.org/perm_income_cons.html)
+- Co-authored [Permanent Income II: LQ Techniques](https://python.quantecon.org/perm_income_cons.html)
 - Co-authored [Reverse Engineering a la Muth](https://python-advanced.quantecon.org/muth_kalman.html)
-- Co-authored code for [Asset Pricing with Incomplete Markets](https://python-intro.quantecon.org/harrison_kreps.html)
-- Co-authored code for [Markov Perfect Equilibrium](https://python-intro.quantecon.org/markov_perf.html)
+- Co-authored code for [Asset Pricing with Incomplete Markets](https://python.quantecon.org/harrison_kreps.html)
+- Co-authored code for [Markov Perfect Equilibrium](https://python.quantecon.org/markov_perf.html)
 - Co-authored code for [Robust Markov Perfect Equilibrium](https://python-advanced.quantecon.org/rob_markov_perf.html)
 - Co-authored code for [Robustness](https://python-advanced.quantecon.org/robustness.html)
 
@@ -153,7 +153,7 @@ We also recognize those who co-authored lectures and code:
 
 - Co-authored [Information and Consumption Smoothing](https://python-advanced.quantecon.org/cons_news.html)
 - Co-authored [Markov Jump Linear Quadratic Dynamic Programming](https://python-advanced.quantecon.org/markov_jump_lq.html)
-- Co-authored [Production Smoothing via Inventories](https://python-intro.quantecon.org/lq_inventories.html)
+- Co-authored [Production Smoothing via Inventories](https://python.quantecon.org/lq_inventories.html)
 
 [Balint Szoke](https://www.balintszoke.com/)
 
@@ -165,10 +165,10 @@ We also recognize those who co-authored lectures and code:
 
 [Natasha Watkins](https://github.com/natashawatkins)
 
-- Co-authored [Application: The Samuelson Multiplier-Accelerator](https://python-intro.quantecon.org/samuelson.html)
-- Co-authored [Linear Regression in Python](https://python-intro.quantecon.org/ols.html)
-- Co-authored [Maximum Likelihood Estimation](https://python-intro.quantecon.org/mle.html)
-- Co-authored [Pandas for Panel Data](https://python-intro.quantecon.org/pandas_panel.html)
+- Co-authored [Application: The Samuelson Multiplier-Accelerator](https://python.quantecon.org/samuelson.html)
+- Co-authored [Linear Regression in Python](https://python.quantecon.org/ols.html)
+- Co-authored [Maximum Likelihood Estimation](https://python.quantecon.org/mle.html)
+- Co-authored [Pandas for Panel Data](https://python.quantecon.org/pandas_panel.html)
 
 Dongchen Zou
 

--- a/pages/python-lectures.md
+++ b/pages/python-lectures.md
@@ -27,7 +27,7 @@ menu_item: false
     </a>
   </li>
   <li>
-    <a href="https://python-intro.quantecon.org/">
+    <a href="https://python.quantecon.org/">
       <svg width="31px" height="38px" viewBox="0 0 31 38" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
           <g id="Greek_Alphabet_clip_art" transform="translate(-97.000000, -285.000000)" fill="#000000" fill-rule="nonzero">


### PR DESCRIPTION
This PR replaces all instances of the url/link `python-intro.quantecon.org` with `python.quantecon.org`. This includes a link to the updated QE menubar which also has the link updated.
Merge PR once the infrastructure for `python-intro` has been shifted to `python` urls.