### PR TITLE
[NEW PAGE] making lecture contribute page and editing contribute page

### DIFF
--- a/pages/contribute-lectures.md
+++ b/pages/contribute-lectures.md
@@ -1,0 +1,109 @@
+
+# Contributing to QuantEcon Lectures
+
+The QuantEcon Lectures has three different lecture series each have their own repository
+* [Python Programming for Economics and Finance](https://github.com/QuantEcon/lecture-python-programming)
+* [Quantitative Economics with Python](https://github.com/QuantEcon/lecture-python)
+* [Advanced Quantitative Economics with Python](https://github.com/QuantEcon/lecture-python-advanced)
+
+## Building notebooks
+
+All lecture source files are written in reStructuredText. To build a jupyter notebook from these files we use [Jupinx](https://jupinx.quantecon.org).
+A jupinx tutorial is available [here](https://jupinx.quantecon.org/tutorial).
+
+## Style Guide - Writing Conventions
+
+If you wish to contribute to these any lecture series, there are a few guidelines to help you along the way.
+These are here to maintain consistency across the lectures.
+
+### Mathematical Notation
+
+Matrices always use square brackets. Use `\begin{bmatrix} ... \end{bmatrix}`
+
+Sequences use curly brackets, such as `\{ x_t \}_{t=0}^{\infty}`
+
+The use of align environments can be done using the `\begin{algined} ... \end{aligned}` as it is not a full math environment and works within the equation wrapping of sphinx.
+
+"Independent and identically distributed" is abbreviated to "IID".
+
+The headings should not use math-environment.
+
+Labels must be written in all small alphabetical letters. Any special character should be avoided in labels except "dash" i.e "-"
+
+All the cite key must use the default google scholar bibtex conventions.
+
+Math lines contained in `.. math::` directives should never start with `+` or `-` as they get interpreted as markdown. This is a temporary issue with `nbconvert`
+
+### Emphasis and Definitions
+
+Use **bold** for definitions and _italic_ for emphasis. For example,
+
+* A **closed set** is a set whose complement is open.
+* All consumers have _identical_ endowments.
+
+### Titles and Headings
+
+* Capitalization of all words for all titles.
+  > Example “How it Works: Data, Variables and Names”
+
+### Adding References
+
+#### Adding a Citation to a Lecture
+
+To add a reference to the text of a QuantEcon lecture you need to use the `:cite:<bibtex-label>` directive.
+
+For example
+
+```
+:cite:`StokeyLucas1989`, chapter 2
+```
+
+is rendered rendered in HTML and LaTex as:
+
+> [SLP89], chapter 2
+
+#### Adding a new reference to QuantEcon
+
+To add a new reference to the project, a bibtex entry needs to be added to `lecture-source-py/source/_static/quant-econ.bib`.
+
+### Sphinx and Restructured Text
+
+#### Editing
+
+The syntax of the source files is reStructuredText.
+
+[Here is a nice primer](http://sphinx-doc.org/rest.html) on how to write reStructuredText files.
+
+[Here is the documentation](http://jinja.pocoo.org/docs/dev/) for the Jinja template syntax.
+
+### Helpful Links
+
+* [A nice Sphinx tutorial](http://sphinx-doc.org/tutorial.html)
+* [Another rst primer](http://docutils.sourceforge.net/docs/user/rst/quickstart.html)
+
+## Building Lectures on OS X
+
+You will need to fetch the Liberation Mono fonts for this repository to build the LaTeX components. 
+
+```bash
+brew tap homebrew/cask-fonts
+brew cask install font-liberation-sans
+brew cask install font-computer-modern
+```
+
+## Converting notebooks to RST files
+
+Sometimes it's convenient to write a lecture as a notebook and then convert to
+RST
+
+This guide is provided by TJS and requires pandoc 2.6 or newer
+
+(Use `pandoc --version` to test)
+
+1.  This step is necessary only if you want to strip out dollar signs from maths
+
+    *  `python latex_space_strip.py  [myinputfile.ipynb] -o [myoutputfile.ipynb]`
+
+2.  To convert, use
+
+    *  `pandoc [myfilenamenew.pynb] -f ipynb+tex_math_dollars -t rst -s -o [newfilename.rst]`

--- a/pages/contribute.md
+++ b/pages/contribute.md
@@ -49,17 +49,9 @@ requirements:
 
 1. If possible, a PR should address just one lecture
 2. Python lectures should execute with the *latest* Anaconda environment.
-   Please update and check prior to submitting your PR. 
+   Please update and check prior to submitting your PR.
 
-If you are not familiar with Git and Github there are some resources available in 
-[resources](#resources) below. 
-
-Lectures are compiled using the [jupinx](https://jupinx.quantecon.org/) tools. 
-A jupinx tutorial is available.[here](https://jupinx.quantecon.org/tutorial).
-
-When making contributions please read the writing style guide for each project:
-
-1. [Python](https://github.com/QuantEcon/lecture-source-py#style-guide---writing-conventions)
+Information on contributing to the python lectures can be found [here](https://quantecon.org/contribute-lectures/)
 
 ## Resources
 


### PR DESCRIPTION
Hey @mmcky this is part of [#57](https://github.com/QuantEcon/lecture-python-website/issues/57)

In this PR I adding `contribute-lectures` page which contains the content of the relevant sections of the README [file](https://github.com/QuantEcon/lecture-source-py/blob/master/README.md).

I have also edited the lecture contributions section on the contribute page to link to this new page

I removed text on `jupinx` on the `contribute` page as I have moved it to the `contribute-lectures` page. Also I thought the text on GitHub as the resources are right below.