### PR TITLE
[Contribute lecture] making page live

### DIFF
--- a/pages/contribute-lectures.md
+++ b/pages/contribute-lectures.md
@@ -1,4 +1,8 @@
-
+---
+title: Contributing to QuantEcon Lectures
+permalink: /contribute-lectures/
+menu_item: false
+---
 # Contributing to QuantEcon Lectures
 
 The QuantEcon Lectures has three different lecture series each have their own repository


### PR DESCRIPTION
Hi @mmcky this make the contribute lectures README page live. I missed the title section in the original PR. This make the link work I believe. Sorry.

See current broken link [here](https://quantecon.org/contribute-lectures/)

Once this link is fixed I will make PR in each lecture README to point to this page.