### PR TITLE
fix URL to Jupyter Book

### DIFF
--- a/_projects/jupyter-book.md
+++ b/_projects/jupyter-book.md
@@ -1,7 +1,7 @@
 ---
 name: Jupyter Book
 description: QuantEcon a founding member of the Executable Books Project, which develops Jupyter Book.
-link: ttps://jupyterbook.org/intro.html
+link: https://jupyterbook.org/intro.html
 image: jupyter-book-logo.svg
 order: 6
 ---


### PR DESCRIPTION
@mmcky I noticed this was missing a character. Unsure if it needs to be edited anywhere else.