### PR TITLE
Add support drop down primary menu item

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,8 +78,14 @@
               {% for node in pages %}
               <li{% if page.url==node.url %} class="active" {% endif %}><a href="{{ node.url | relative_url }}">{{
                   node.title }}</a></li>
-                {% endfor %}
-                <li><a href="https://github.com/QuantEcon" target="_blank">GitHub</a></li>
+              {% endfor %}
+              <li><a href="https://github.com/QuantEcon" target="_blank">GitHub</a></li>
+              <li class="dropdown"><a href="#"><span>Support</span> <i class="bi bi-chevron-down"></i></a>
+                <ul>
+                  <li><a href="/store/">Merchandise</a></li>
+                  <li><a href="https://numfocus.org/donate-to-quantecon" target="_blank">Donate</a></li>
+                </ul>
+              </li>
           </ul>
           <i class="bi bi-list mobile-nav-toggle"></i>
         </nav><!-- .navbar -->

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -210,7 +210,7 @@ img {
     .active a,
     .active:focus,
     li:hover>a {
-      color: inherit;
+      color: $color-link;
       text-decoration: none;
     }   
   }
@@ -247,11 +247,12 @@ img {
       visibility: hidden;
       background: #fff;
       box-shadow: 0px 0px 30px rgba(127, 137, 161, 0.25);
+      border: 1px solid $color-light;
       transition: 0.3s;
       li {
-        min-width: 200px;
+        min-width: 100px;
         a {
-          padding: 10px 20px;
+          padding: 0.1rem 1rem;
           font-size: 14px;
           color: #2c4964;
           i {
@@ -262,7 +263,7 @@ img {
       a:hover,
       .active:hover,
       li:hover>a {
-        color: #5846f9;
+        color: $color-link;
       }
     }
     &:hover>ul {
@@ -287,6 +288,8 @@ img {
 
   }
 }
+
+
 
 @media (max-width: 1366px) {
   .navbar .dropdown .dropdown ul {
@@ -374,7 +377,7 @@ img {
   .dropdown {
     ul {
       position: static;
-      display: none;
+      //display: none;
       margin: 10px 20px;
       padding: 10px 0;
       z-index: 99;


### PR DESCRIPTION
Merchandise needs to be easier to find. It now lives in the primary navigation at the top of each page under "Support".

@mmcky Just asking for a review please. Not much change, just rearranged the primary menu `<ul>` list and tweaked mobile styles for the menu.