### PR TITLE
Fix menu, add lectures

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -79,6 +79,7 @@
               <li{% if page.url==node.url %} class="active" {% endif %}><a href="{{ node.url | relative_url }}">{{
                   node.title }}</a></li>
               {% endfor %}
+              <li><a href="/projects/#filter=lecture">Lectures</a></li>
               <li><a href="https://github.com/QuantEcon" target="_blank">GitHub</a></li>
               <li class="dropdown"><a href="#"><span>Support</span> <i class="bi bi-chevron-down"></i></a>
                 <ul>

--- a/pages/about.md
+++ b/pages/about.md
@@ -2,6 +2,7 @@
 title: About
 permalink: /about/
 menu_item: true
+layout: about
 ---
 # About
 

--- a/pages/team.md
+++ b/pages/team.md
@@ -1,9 +1,0 @@
----
-title: Team
-permalink: /team/
-menu_item: true
-layout: team
----
-# Team
-
-


### PR DESCRIPTION
Removing the dead team page from navigation (team was merged with About).
Adding a direct link to lectures.