### PR TITLE
Add intro

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -79,7 +79,7 @@
               <li{% if page.url==node.url %} class="active" {% endif %}><a href="{{ node.url | relative_url }}">{{
                   node.title }}</a></li>
               {% endfor %}
-              <li><a href="/projects/#filter=lecture">Lectures</a></li>
+              <!-- <li><a href="/projects/#filter=lecture">Lectures</a></li> -->
               <li><a href="https://github.com/QuantEcon" target="_blank">GitHub</a></li>
               <li class="dropdown"><a href="#"><span>Support</span> <i class="bi bi-chevron-down"></i></a>
                 <ul>

--- a/_projects/lecture-advanced.md
+++ b/_projects/lecture-advanced.md
@@ -3,6 +3,6 @@ name: Advanced Quantitative Economics with Python
 description: This is one of a series of online texts on modern quantitative economics and programming with Python. This is the third text in the series, which focuses on advanced topics.
 link: https://python-advanced.quantecon.org/
 image: project-lectures.png
-order: 3
+order: 4
 type: lecture
 ---

--- a/_projects/lecture-datascience.md
+++ b/_projects/lecture-datascience.md
@@ -3,6 +3,6 @@ name: Introduction to Economic Modeling and Data Science
 description: A series of lectures on programming, data science, and economics.
 link: https://datascience.quantecon.org/
 image: project-lectures.png
-order: 5
+order: 6
 type: lecture
 ---

--- a/_projects/lecture-intro.md
+++ b/_projects/lecture-intro.md
@@ -3,6 +3,6 @@ name: A First Course in Quantitative Economics with Python
 description: This lecture series provides an introduction to quantitative economics using Python.
 link: https://intro.quantecon.org/
 image: project-lectures.png
-order: 8
+order: 2
 type: lecture
 ---

--- a/_projects/lecture-intro.md
+++ b/_projects/lecture-intro.md
@@ -1,0 +1,8 @@
+---
+name: A First Course in Quantitative Economics with Python
+description: This lecture series provides an introduction to quantitative economics using Python.
+link: https://intro.quantecon.org/
+image: project-lectures.png
+order: 8
+type: lecture
+---

--- a/_projects/lecture-jax.md
+++ b/_projects/lecture-jax.md
@@ -3,6 +3,6 @@ name: Quantitative Economics with JAX
 description: This website presents a set of lectures on quantitative economic modeling using GPUs and Google JAX.
 link: https://jax.quantecon.org/
 image: project-lectures.png
-order: 7
+order: 8
 type: lecture
 ---

--- a/_projects/lecture-markov.md
+++ b/_projects/lecture-markov.md
@@ -3,6 +3,6 @@ name: Continuous Time Markov Chains
 description: This lecture series provides a short introduction to the fascinating field of continuous time Markov chains.
 link: https://quantecon.github.io/continuous_time_mcs/
 image: project-lectures.png
-order: 6
+order: 7
 type: lecture
 ---

--- a/_projects/lecture-python.md
+++ b/_projects/lecture-python.md
@@ -1,8 +1,8 @@
 ---
-name: Quantitative Economics with Python
+name: Intermediate Quantitative Economics with Python
 description: This is one of a series of online texts on modern quantitative economics and programming with Python. This is the second text in the series, which focuses on introductory material.
 link: https://python.quantecon.org/
 image: project-lectures.png
-order: 2
+order: 3
 type: lecture
 ---


### PR DESCRIPTION
Hi @jstac, this PR removes the current `Lectures` label on the toolbar and adds intro series to `Projects`.

I think we should make the `Lectures` label back after some changes and not a simple link to `Project/lectures`.