### PR TITLE
ENH: update redirects for python-pages

### DIFF
--- a/pages/python-lectures.md
+++ b/pages/python-lectures.md
@@ -1,39 +1,8 @@
 ---
 title: 'Quantitative Economics with Python'
 permalink: /python-lectures/
+redirect_to: https://quantecon.org/projects/#filter=lecture
 menu_item: false
 ---
 
 # Quantitative Economics with Python
-
-<div class="py-home-intro">
-  <p>This project provides a series of online textbooks on Python programming and quantitative economic modeling, designed and written by Thomas J. Sargent and John Stachurski. <a href="/about-python-lectures/">Read more...</a></p>
-
-</div>
-
-<ul class="py-series">
-  <li>
-    <a href="https://python-programming.quantecon.org/">
-      Python Programming for Economics and Finance
-    </a>
-  </li>
-  <li>
-    <a href="https://python.quantecon.org/">
-      Quantitative Economics with Python
-    </a>
-  </li>
-  <li>
-    <a href="https://python-advanced.quantecon.org/">
-      Advanced Quantitative Economics with Python
-    </a>
-  </li>
-</ul>
-
-<ul class="py-sponsors">
-  <li>
-    <a href="http://www.sloan.org/" title="Alfred P. Sloan Foundation"><img src="/assets/img/alfred-p-sloan-logo.png" alt="Sponsored by the Alfred P. Sloan Foundation" width="350"></a>
-  </li>
-  <li>
-    <a href="https://quantecon.org/"><img src="/assets/img/schmidtfutures-logo.png" width="400"></a>
-  </li>
-</ul>


### PR DESCRIPTION
This updates /python-pages/ to https://quantecon.org/projects/#filter=lecture

fixes https://github.com/QuantEcon/meta/issues/113

- [ ] open issue to update links across projects rather than depend on a redirect