### PR TITLE
MAINT: Split current and past sponsors

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -33,8 +33,6 @@ layout: default
 
       <div class="row align-items-center text-center">
 
-        <p><b>Current Sponsors</b></p>
-
         <div>
           <p style="margin-bottom:2cm;">
           <a href="https://chow.xmu.edu.cn/en/index.htm" title="Paula and Gregory Chow Institute for Studies in Economics, Xiamen University">
@@ -44,22 +42,10 @@ layout: default
           </p>
         </div>
 
-        <p><b>Past Sponsors</b></p>
-
-        <div class="col-md-5 offset-md-1">
-          <p class="m-0"><a href="http://www.sloan.org/" title="Alfred P. Sloan Foundation"><img
-                src="/assets/img/alfred-p-sloan-logo.png" width="350"
-                alt="Sponsored by the Alfred P. Sloan Foundation"></a></p>
-        </div>
-        <div class="col-md-5 mt-5 mt-md-0">
-          <p class="m-0"><a href="https://schmidtfutures.com/">
-              <img src="/assets/img/schmidt-logo.svg" alt="Schmidt Futures logo" width="400"></a></p>
-        </div>
       </div>
     </div>
 
   </section>
-
 
   <section id="featured" class="featured">
     <!-- Lectures and Code Libraries -->
@@ -288,5 +274,29 @@ layout: default
     </div>
 
   </section><!-- End Services Section -->
+
+  <!-- Past Sponsors -->
+  <section id="sponsors" class="sponsors section-bg">
+
+    <div class="container">
+
+      <div class="row align-items-center text-center">
+
+        <p><b>Past Sponsors</b></p>
+
+        <div class="col-md-5 offset-md-1">
+          <p class="m-0"><a href="http://www.sloan.org/" title="Alfred P. Sloan Foundation"><img
+                src="/assets/img/alfred-p-sloan-logo.png" width="350"
+                alt="Sponsored by the Alfred P. Sloan Foundation"></a></p>
+        </div>
+        <div class="col-md-5 mt-5 mt-md-0">
+          <p class="m-0"><a href="https://schmidtfutures.com/">
+              <img src="/assets/img/schmidt-logo.svg" alt="Schmidt Futures logo" width="400"></a></p>
+        </div>
+
+      </div>
+    </div>
+
+  </section>
 
 </main><!-- End #main -->

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -33,6 +33,8 @@ layout: default
 
       <div class="row align-items-center text-center">
 
+        <p><b>Sponsors</b></p>
+
         <div>
           <p style="margin-bottom:2cm;">
           <a href="https://chow.xmu.edu.cn/en/index.htm" title="Paula and Gregory Chow Institute for Studies in Economics, Xiamen University">


### PR DESCRIPTION
This PR moves previous sponsors to the bottom of the page, keeping current sponsors at the top of the page. 