### PR TITLE
MAINT: Remove discourse from website

### DIFF
--- a/_includes/quantecon-menubar.html
+++ b/_includes/quantecon-menubar.html
@@ -33,7 +33,7 @@
 				<span>Community</span>
 				<ul>
 				<li><a href="http://blog.quantecon.org/" title="Blog"><span>Blog</span></a></li>
-				<li><a href="http://discourse.quantecon.org/" title="Forum"><span>Forum</span></a></li>
+				<!-- <li><a href="http://discourse.quantecon.org/" title="Forum"><span>Forum</span></a></li> -->
 				</ul>
 			</li>
 		</ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -95,7 +95,7 @@
             </li>
             <li{% if page.layout=='news' %} class="active" {% endif %}><a href="/news/"><span>News</span></a></li>
             <li class="github-link"><a href="https://github.com/QuantEcon" target="_blank" title="GitHub"><i class="bi bi-github" style="font-size:30px;"></i></a></li>
-            <li class="github-link"><a href="https://discourse.quantecon.org/" target="_blank" title="Discourse"><i class="bi bi-chat-text" style="font-size:30px;"></i></a></li>
+            <!-- <li class="github-link"><a href="https://discourse.quantecon.org/" target="_blank" title="Discourse"><i class="bi bi-chat-text" style="font-size:30px;"></i></a></li> -->
           </ul>
           <i class="bi bi-list mobile-nav-toggle"></i>
         </nav><!-- .navbar -->

--- a/_posts/2025-03-17-discourse-closure.md
+++ b/_posts/2025-03-17-discourse-closure.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: Closure of discourse.quantecon.org
+author: Matt McKay
+excerpt: Closing the discourse.quantecon.org forum
+#type: article
+---
+
+The QuantEcon organization is closing the discourse forum (running since 2016) hosted at
+[discourse.quantecon.org](https://discourse.quantecon.org).
+
+We have recently observed a large increase in spam posts. As the forum was not seeing high usage rates
+we felt the maintenance cost was higher than the benefit it was bringing to the broader community. 
+
+We are still dedicated to encouraging community linkages and discussion and will be evaluating new
+platforms and opportunities. We are also looking at developing AI tutors for our lecture sites.
+
+Thank you to everyone that participated in the forums. 

--- a/pages/404.md
+++ b/pages/404.md
@@ -14,5 +14,4 @@ Please check the URL or try a link below:
 -   [Quantitative Economics with Python](https://python.quantecon.org/)
 -   [Quantitative Economics with Julia](https://julia.quantecon.org/)
 -   [QuantEcon DataScience](https://datascience.quantecon.org/)
--   [Forum](http://discourse.quantecon.org/)
 -   [Contact us](mailto:contact@quantecon.org)


### PR DESCRIPTION
This PR updates pages to remove the discourse forum and adds a news item.