### PR TITLE
Remove colorscale argument and use default color in map view

### DIFF
--- a/pages/analytics_dashboard.html
+++ b/pages/analytics_dashboard.html
@@ -41,7 +41,6 @@ menu_item: false
         z: usersArr,
         text: hoverText,
         hovertemplate: "<b>Country: %{text}</b><br>Users: %{z}<extra></extra>",
-        colorscale: 'Teal',
         colorbar: {
           title: 'Users'
         }


### PR DESCRIPTION
Remove `colorscale` argument and use default color in map view