### PR TITLE
ENH: Add analytics dashboard

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -91,6 +91,7 @@
                 <li><a href="/store">Merch</a></li>
                 <li><a href="https://numfocus.org/donate-to-quantecon" target="_blank">Donate</a></li>
                 <li><a href="/sponsors">Sponsors</a></li>
+                <li><a href="/analytics-dashboard">Analytics</a></li>
               </ul>
             </li>
             <li{% if page.layout=='news' %} class="active" {% endif %}><a href="/news/"><span>News</span></a></li>

--- a/pages/analytics_dashboard.html
+++ b/pages/analytics_dashboard.html
@@ -6,7 +6,7 @@ menu_item: false
 
 <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 
-<h1>Analytics Dashboard</h1>
+
 
 <h2>Active Users by Country</h2>
 <div id="map-container" class="chart-container"></div>

--- a/pages/analytics_dashboard.html
+++ b/pages/analytics_dashboard.html
@@ -14,6 +14,9 @@ menu_item: false
 <h2>Monthly Users</h2>
 <div id="month-container" class="chart-container"></div>
 
+<h2>Active Users (per capita) by Country</h2>
+<div id="map-container-percapita" class="chart-container"></div>
+
 <script>
   const BASE_DATA_URL = "https://quantecon.github.io/website-dynamic";
 
@@ -41,7 +44,7 @@ menu_item: false
         z: usersArr,
         text: hoverText,
         hovertemplate: "<b>Country: %{text}</b><br>Users: %{z}<extra></extra>",
-        colorscale: 'Picnic',
+        colorscale: 'Portland',
         colorbar: {
           title: 'Users'
         }
@@ -108,4 +111,52 @@ menu_item: false
     .catch(err => {
       console.error("Error loading month_data.json:", err);
     });
+
+/**
+* 3. Fetch and Render the Choropleth Map (per capita)
+*/
+fetch(`${BASE_DATA_URL}/map_data.json`)
+ .then(response => {
+   if (!response.ok) {
+     throw new Error("Network response was not ok " + response.statusText);
+   }
+   return response.json();
+ })
+ .then(data => {
+   // data is an array of objects:
+   // [ { country: "Australia", iso_alpha_3: "AUS", users: 123 }, ... ]
+
+   const isoCodes = data.map(row => row.iso_alpha_3);
+   const usersArr = data.map(row => row.users_per_capita);
+   const hoverText = data.map(row => row.country);
+
+   const trace = {
+     type: 'choropleth',
+     locations: isoCodes,
+     z: usersArr,
+     text: hoverText,
+     hovertemplate: "<b>Country: %{text}</b><br>Users (per capita): %{z}<extra></extra>",
+     colorscale: 'Portland',
+     colorbar: {
+       title: 'Users (per capita)'
+     }
+   };
+
+   const layout = {
+     title: 'Active Users (per capita) by Country (last six months)',
+     geo: {
+       showframe: false,
+       showcoastlines: true,
+       projection: { type: 'natural earth' }
+     },
+     margin: { l: 0, r: 0, t: 50, b: 0 },
+     title_x: 0.5
+   };
+
+   Plotly.newPlot('map-container-percapita', [trace], layout);
+ })
+ .catch(err => {
+   console.error("Error loading map_data.json:", err);
+ });
+
 </script>


### PR DESCRIPTION
This PR adds the analytics dashboard to be under the `About` dropbdown

It includes aggregated `User` stats across our lecture sites with data derived from `google analytics`

The dataset is currently updated monthly in https://github.com/quantecon/website-dynamic and hosted via `gh-pages`