### PR TITLE
Add news post: Python lectures update (September 2025)

### DIFF
--- a/_posts/2025-09-15-python-lectures-update.md
+++ b/_posts/2025-09-15-python-lectures-update.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: "Updates to QuantEcon Python Lecture Series"
+author: Matt McKay
+excerpt: QuantEcon's Python lecture series continues to expand with new content on monetary economics, optimization, and enhanced JAX integration for high-performance computing.
+---
+
+QuantEcon's Python lecture series has seen significant updates over the past year, with new lectures, improved content, and expanded GPU acceleration support.
+
+## New Lectures Added
+
+Recent additions to [A First Course in Quantitative Economics with Python](https://intro.quantecon.org/) include:
+
+- **Monetary Economics**: New lectures on monetarist theory of price levels, including the Cagan model with both rational and adaptive expectations, and analysis of historical inflation episodes
+- **Optimization**: An introduction to linear programming covering production problems, investment decisions, and the simplex method
+- **Market Dynamics**: The cobweb model exploring price dynamics under different expectation formation mechanisms
+- **Mathematical Foundations**: Computing square roots using classical Greek methods and eigenvalue analysis
+
+The [Intermediate Quantitative Economics with Python](https://python.quantecon.org/) series has also expanded with:
+
+- **Overlapping Generations Models**: Comprehensive coverage including transition dynamics and fiscal policy analysis (Cass-Koopmans with distorting taxes)
+- **Heterogeneous Agent Models**: Extended Aiyagari model with long-lived agents and OLG structure
+- **Statistical Methods**: New lectures on exchangeability, Bayesian updating, and likelihood ratio processes
+
+## Enhanced JAX Integration
+
+Many lectures now feature [JAX](https://github.com/google/jax) implementations, providing GPU acceleration for computationally intensive economic models. This includes the McCall search model, Aiyagari model, lake model of employment, and income fluctuation problems. These implementations demonstrate significant speedups when running on GPU hardware.
+
+## Contributors
+
+We extend our thanks to the research assistants and contributors who made these updates possible, including Longye Tian, Humphrey Yang, Shu Hu, Smit Lunagariya, and many others listed in our [credits](https://intro.quantecon.org/about.html).
+
+The lectures remain freely available and we continue to welcome contributions via our [GitHub repositories](https://github.com/QuantEcon).


### PR DESCRIPTION
This PR adds a news post announcing the recent updates to the Python lecture series, including:

- New monetary economics lectures (Cagan adaptive expectations, fiscal inflation)
- Linear programming optimization lectures
- Cobweb model and OLG model additions
- JAX integration for GPU-accelerated computations

Dated September 2025 to reflect when these updates were made.