### PR TITLE
Add news post: Optimal savings and parallel programming updates (November 2025)

### DIFF
--- a/_posts/2025-11-25-optimal-savings-parallel-programming-updates.md
+++ b/_posts/2025-11-25-optimal-savings-parallel-programming-updates.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: "Reorganized Optimal Savings and Parallel Programming Lectures"
+author: QuantEcon
+excerpt: Major reorganization of optimal savings lectures on python.quantecon.org and parallel programming lectures on python-programming.quantecon.org for improved learning flow.
+---
+
+We've completed a significant reorganization of lectures across two of our Python lecture sites to improve content flow and learning progression.
+
+## Optimal Savings Lectures (python.quantecon.org)
+
+The [Intermediate Quantitative Economics with Python](https://python.quantecon.org/) series has undergone a major restructuring of the optimal savings content:
+
+- **Renamed and reorganized** the income fluctuation problem (IFP) lectures for clearer progression
+- **Added dynamics plots** and adjusted parameters for better visualization
+- **Improved code organization** with consistent function signatures across lectures
+- **Enhanced JAX implementations** with unified operator signatures between standard and JAX versions
+
+## Parallel Programming Lectures (python-programming.quantecon.org)
+
+The [Python Programming for Economics and Finance](https://python-programming.quantecon.org/) site now features reorganized parallel programming content:
+
+- **Restructured table of contents** for better topic flow
+- **Improved content** on NumPy vs Numba vs JAX comparisons
+- **Better explanations** of parallel computing concepts
+
+These updates were developed with contributions from John Stachurski, Humphrey Yang, and Matt McKay.


### PR DESCRIPTION
Announces the reorganization of optimal savings lectures on python.quantecon.org and parallel programming lectures on python-programming.quantecon.org.

Based on commits from November 20-25, 2025.