### PR TITLE
Add news post: IFP lectures with wealth inequality analysis (December 2025)

### DIFF
--- a/_posts/2025-12-02-ifp-wealth-inequality-lectures.md
+++ b/_posts/2025-12-02-ifp-wealth-inequality-lectures.md
@@ -5,7 +5,7 @@ author: QuantEcon
 excerpt: Expanded income fluctuation problem lectures now include transient income shocks, wealth inequality analysis, and labor income volatility studies.
 ---
 
-The [Intermediate Quantitative Economics with Python](https://python.quantecon.org/) series has been expanded with significant new content on income fluctuation problems and wealth inequality.
+The [Quantitative Economics with Python](https://python.quantecon.org/) series has been expanded with significant new content on income fluctuation problems and wealth inequality.
 
 ## New Lecture Content
 


### PR DESCRIPTION
Announces expanded income fluctuation problem lectures with transient income shocks and wealth inequality analysis on python.quantecon.org.

Based on commits from November 28 - December 2, 2025.