### PR TITLE
Add news post: Gorman aggregation lecture (December 2025)

### DIFF
--- a/_posts/2025-12-28-gorman-aggregation-lecture.md
+++ b/_posts/2025-12-28-gorman-aggregation-lecture.md
@@ -5,7 +5,7 @@ author: QuantEcon
 excerpt: A new lecture on Gorman aggregation has been added to the Advanced Quantitative Economics series, exploring conditions under which heterogeneous household economies can be represented by a single representative agent.
 ---
 
-We're pleased to announce a new lecture on [Advanced Quantitative Economics with Python](https://python-advanced.quantecon.org/): **Gorman Aggregation with Heterogeneous Households**.
+We're pleased to announce a new lecture on [Advanced Quantitative Economics with Python](https://python-advanced.quantecon.org/): **[Gorman Aggregation with Heterogeneous Households](https://python-advanced.quantecon.org/gorman_aggregation.html)**.
 
 ## About the Lecture
 


### PR DESCRIPTION
Announces new advanced lecture on Gorman aggregation conditions for representative agent models on advanced.quantecon.org.

Based on commits from December 27-28, 2025.