### PR TITLE
Fix Gorman aggregation lecture URL

### DIFF
--- a/_posts/2025-12-28-gorman-aggregation-lecture.md
+++ b/_posts/2025-12-28-gorman-aggregation-lecture.md
@@ -6,7 +6,7 @@ excerpt: A new lecture on Gorman aggregation has been added to the Advanced Quan
 tag: [lectures]
 ---
 
-We're pleased to announce a new lecture on [Advanced Quantitative Economics with Python](https://python-advanced.quantecon.org/): **[Gorman Aggregation with Heterogeneous Households](https://python-advanced.quantecon.org/gorman_aggregation.html)**.
+We're pleased to announce a new lecture on [Advanced Quantitative Economics with Python](https://python-advanced.quantecon.org/): **[Gorman Aggregation with Heterogeneous Households](https://python-advanced.quantecon.org/gorman_heterogeneous_households.html)**.
 
 **About the Lecture**
 


### PR DESCRIPTION
Fix broken link to Gorman aggregation lecture. The URL was gorman_aggregation.html but the correct path is gorman_heterogeneous_households.html.