### PR TITLE
Add build-time cache-busting to main CSS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,7 +47,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css" />
 
   <!-- Template Main CSS File -->
-  <link href="/assets/main.css" rel="stylesheet">
+  <link href="/assets/main.css?v={{ site.time | date: '%Y%m%d%H%M%S' }}" rel="stylesheet">
   <link rel="icon" href="{{ '/assets/img/favicon.ico' | relative_url }}" type="image/x-icon" />
 </head>
 


### PR DESCRIPTION
## Summary

Appends the Jekyll build timestamp to the main CSS URL so browsers always fetch the latest stylesheet after a deployment, preventing stale CSS from being served.

**Before:**
```html
<link href="/assets/main.css" rel="stylesheet">
```

**After:**
```html
<link href="/assets/main.css?v={{ site.time | date: '%Y%m%d%H%M%S' }}" rel="stylesheet">
```

The query string changes on every build, so browsers treat it as a new resource and bypass their cache. No manual version bumping required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)