### PR TITLE
ci: add Dependabot config for bundler and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep Ruby gems (Jekyll + plugins) up to date
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated dependency update PRs. The original jQuery XSS alerts raised in #93 have already been resolved; this config ensures future vulnerabilities and updates are surfaced automatically.

## What's configured

| Ecosystem | Directory | Schedule |
|---|---|---|
| `bundler` | `/` | Weekly — keeps Jekyll gems (`Gemfile.lock`) current |
| `github-actions` | `/` | Weekly — keeps workflow action versions current (e.g. `actions/checkout`, `ruby/setup-ruby`) |

No npm/yarn ecosystem is needed — the repo has no `package.json`.

Closes #93