### PR TITLE
Add Thomas J. Sargent as co-author of Economic Networks

### DIFF
--- a/_projects/networks.md
+++ b/_projects/networks.md
@@ -1,6 +1,6 @@
 ---
 name: Economic Networks
-authors: "John Stachurski"
+authors: "John Stachurski and Thomas J. Sargent"
 description: "This book is an introduction to economic networks and it emphasizes quantitative modeling, with the main underlying tools being graph theory, linear algebra, fixed point theory and programming."
 link: https://networks.quantecon.org
 image: networks-image.png


### PR DESCRIPTION
## Summary
- Adds Thomas J. Sargent as co-author alongside John Stachurski for the Economic Networks book entry on https://quantecon.org/books/
- Per feedback from @jstac 

## Test plan
- [ ] Verify the books page renders "John Stachurski and Thomas J. Sargent" under Economic Networks

🤖 Generated with [Claude Code](https://claude.com/claude-code)