### PR TITLE
infrastructure: expand Jupinx entry, note sphinxcontrib-jupyter deprecation

### DIFF
--- a/pages/infrastructure.html
+++ b/pages/infrastructure.html
@@ -133,9 +133,12 @@ layout: default
                 <h3>Jupinx <small class="text-muted">(Historical)</small></h3>
                 <div class="timeline-date">2019</div>
                 <p>
-                    QuantEcon built <a href="https://jupinx.quantecon.org/">Jupinx</a>, an open source tool for converting
-                    ReStructuredText source files into a website via Jupyter Notebooks.
-                    <em>Note: Jupinx has been superseded by Jupyter Book.</em>
+                    QuantEcon built <a href="https://jupinx.quantecon.org/">Jupinx</a>, an open source command-line build
+                    tool for the lecture series. It paired a <code>quickstart</code> project scaffolder with a unified
+                    build driver that turned reStructuredText sources into executed Jupyter notebooks, PDFs, and a
+                    notebook-backed website, with support for parallel execution and coverage testing. Jupinx wrapped the
+                    <a href="https://github.com/QuantEcon/sphinxcontrib-jupyter">sphinxcontrib-jupyter</a> extension.
+                    <em>Note: Jupinx has been superseded by Jupyter Book and MyST.</em>
                 </p>
                 <p><b>Funding:</b> <a href="https://sloan.org">Alfred P. Sloan Foundation</a></p>
             </div>
@@ -145,7 +148,9 @@ layout: default
                 <div class="timeline-date">2018</div>
                 <p>
                     QuantEcon developed <a href="https://github.com/QuantEcon/sphinxcontrib-jupyter">sphinxcontrib-jupyter</a>,
-                    a sphinx extension that enabled the generation of Jupyter notebooks from reStructuredText source files.
+                    a Sphinx extension that enabled the generation of Jupyter notebooks from reStructuredText source files.
+                    <em>Note: sphinxcontrib-jupyter has been deprecated; its notebook writers were migrated to
+                    <a href="https://github.com/QuantEcon/sphinx-tojupyter">sphinx-tojupyter</a> for the MyST toolchain.</em>
                 </p>
                 <p><b>Funding:</b> <a href="https://sloan.org">Alfred P. Sloan Foundation</a></p>
             </div>


### PR DESCRIPTION
Updates the [infrastructure timeline](https://quantecon.org/infrastructure/) following a review of `jupinx` and `sphinxcontrib-jupyter`.

## Changes

**Jupinx (2019, Historical)** — the previous one-liner undersold what the tool did. Expanded to describe it accurately: a command-line build tool pairing a `quickstart` project scaffolder with a unified build driver that produced executed Jupyter notebooks, PDFs, and a notebook-backed website (with parallel execution and coverage testing), wrapping the `sphinxcontrib-jupyter` extension. Kept the "superseded by Jupyter Book / MyST" note. The repo remains available for historical reference.

**sphinxcontrib-jupyter (2018)** — added a note that it is now deprecated and its notebook writers were migrated to [`sphinx-tojupyter`](https://github.com/QuantEcon/sphinx-tojupyter). (The repo is being archived; banner added in QuantEcon/sphinxcontrib-jupyter#346.)

Also fixed "sphinx" → "Sphinx" in the sphinxcontrib-jupyter entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)