### PR TITLE
fix: valid feed.xml output, repoint /python-lectures/ redirect to /lectures/

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -17,7 +17,7 @@ layout: null
                 {{ post.url | prepend: site.url }}
             </link>
             <description>
-                {{ post.content | escape | truncate: '400' }}
+                {{ post.content | strip_html | truncate: 400 | escape }}
             </description>
             <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
             <guid>

--- a/pages/python-lectures.md
+++ b/pages/python-lectures.md
@@ -1,7 +1,7 @@
 ---
 title: 'Quantitative Economics with Python'
 permalink: /python-lectures/
-redirect_to: https://quantecon.org/projects/#filter=lecture
+redirect_to: https://quantecon.org/lectures/
 menu_item: false
 ---
 


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs discovered while verifying the GitHub Actions deploy migration (#199). Neither was a regression — both pre-date the deployment switch.

## 1. `feed.xml` produced invalid XML

The template rendered post descriptions with `{{ post.content | escape | truncate: '400' }}`. Truncating **after** escaping slices XML entities in half (e.g. `&quot;` → `&quo`), so the live feed failed XML validation with ~10 parser errors.

**Fix:** reorder to `{{ post.content | strip_html | truncate: 400 | escape }}` — truncate plain text first, escape last. `strip_html` also removes markup that previously appeared escaped inside descriptions, so readers get clean text summaries.

Verified: `xmllint --noout _site/feed.xml` passes on a `JEKYLL_ENV=production` build.

## 2. `/python-lectures/` redirected to a page that has never existed

`pages/python-lectures.md` had `redirect_to: https://quantecon.org/projects/#filter=lecture`, but `/projects/` 404s and is absent from the sitemap both before and after the deploy migration — the filterable projects page it pointed at was never shipped. Visitors following the redirect landed on a 404.

**Fix:** point it at `/lectures/`, where the lecture series are listed today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)