### PR TITLE
feat: redirect removed developer pages to their new homes

### DIFF
--- a/pages/developer-resources.md
+++ b/pages/developer-resources.md
@@ -1,0 +1,6 @@
+---
+title: Developer Resources
+permalink: /developer-resources/
+redirect_to: https://quantecon.org/code/
+menu_item: false
+---

--- a/pages/developer-resources.md
+++ b/pages/developer-resources.md
@@ -1,6 +1,6 @@
 ---
 title: Developer Resources
 permalink: /developer-resources/
-redirect_to: https://quantecon.org/code/
+redirect_to: /code/
 menu_item: false
 ---

--- a/pages/julia-developers.md
+++ b/pages/julia-developers.md
@@ -1,0 +1,6 @@
+---
+title: Contribute to QuantEcon.jl
+permalink: /julia-developers/
+redirect_to: https://quantecon.github.io/QuantEcon.jl/latest/man/contributing.html
+menu_item: false
+---

--- a/pages/python-developers.md
+++ b/pages/python-developers.md
@@ -1,0 +1,6 @@
+---
+title: Contribute to QuantEcon.py
+permalink: /python-developers/
+redirect_to: https://quanteconpy.readthedocs.io/en/latest/contributing.html
+menu_item: false
+---

--- a/pages/wiki-py-conda-dev-env.md
+++ b/pages/wiki-py-conda-dev-env.md
@@ -1,0 +1,6 @@
+---
+title: Creating a Conda development environment
+permalink: /wiki-py-conda-dev-env/
+redirect_to: https://quanteconpy.readthedocs.io/en/latest/contributing.html#set-up-a-conda-development-environment
+menu_item: false
+---

--- a/pages/wiki-py-docstrings.md
+++ b/pages/wiki-py-docstrings.md
@@ -1,0 +1,6 @@
+---
+title: Docstrings and Documentation
+permalink: /wiki-py-docstrings/
+redirect_to: https://quanteconpy.readthedocs.io/en/latest/contributing.html#write-documentation
+menu_item: false
+---

--- a/pages/wiki-py-unit-testing.md
+++ b/pages/wiki-py-unit-testing.md
@@ -1,0 +1,6 @@
+---
+title: Unit Testing in QuantEcon
+permalink: /wiki-py-unit-testing/
+redirect_to: https://quanteconpy.readthedocs.io/en/latest/contributing.html#write-tests
+menu_item: false
+---

--- a/pages/wiki.md
+++ b/pages/wiki.md
@@ -1,0 +1,6 @@
+---
+title: Developer Wiki
+permalink: /wiki/
+redirect_to: https://quanteconpy.readthedocs.io/en/latest/contributing.html
+menu_item: false
+---


### PR DESCRIPTION
## Summary

Follow-up to #201, which deleted 7 developer instruction pages and left their URLs 404ing. Those URLs were live for years — they're in search indexes and linked from old Discourse threads and project docs — so this restores each one as a tiny `redirect_to` stub (front matter only, same pattern as `pages/python-lectures.md`).

## Redirect map

| Old URL | Redirects to |
|---|---|
| `/python-developers/` | https://quanteconpy.readthedocs.io/en/latest/contributing.html |
| `/wiki/` | https://quanteconpy.readthedocs.io/en/latest/contributing.html |
| `/wiki-py-conda-dev-env/` | …`/contributing.html#set-up-a-conda-development-environment` |
| `/wiki-py-docstrings/` | …`/contributing.html#write-documentation` |
| `/wiki-py-unit-testing/` | …`/contributing.html#write-tests` |
| `/julia-developers/` | https://quantecon.github.io/QuantEcon.jl/latest/man/contributing.html |
| `/developer-resources/` | `/code/` (the site's own libraries hub) |

All targets verified returning 200. The section anchors are best-effort: if readthedocs restructures the page the fragment stops scrolling but the page still loads.

## Verified

- `bundle exec jekyll build` passes; all 7 stubs emit correct `http-equiv="refresh"` redirects in `_site`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)