### PR TITLE
maint: replace deprecated Sass @import with @use

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -5,8 +5,8 @@
 # v2.0 - Redesign
 --------------------------------------------------------------*/
 
-@import 'misc';
-@import 'timeline';
+@use 'misc';
+@use 'timeline';
 @import url('https://fonts.googleapis.com/css2?family=Exo+2:wght@200;400&family=Roboto:wght@400;700&display=swap');
 $font-brand: 'Exo 2', sans-serif;
 $font-main: 'Roboto', sans-serif;


### PR DESCRIPTION
## Summary

Closes #205 — completes the Sass follow-up from #199. Now that production builds with the Gemfile's Jekyll 4.4 / Dart Sass toolchain (instead of the legacy Pages sandbox), the modern module directives can be used.

## Changes

`assets/main.scss`: `@import 'misc'` / `@import 'timeline'` → `@use 'misc'` / `@use 'timeline'`. The plain-CSS `@import url(...)` for Google Fonts is untouched — that form is not deprecated, and Dart Sass hoists it to the top of the compiled output where browsers require it.

Both partials are pure CSS rules — they define no Sass variables and reference none from `main.scss` — so `@use` namespacing changes nothing.

## Verified

- Compiled `_site/assets/main.css` is **byte-identical** before and after the change.
- The build log drops all `DEPRECATION WARNING [import]` noise (previously one per `@import` per build).

## Note on the other #199 follow-up

"Drop the `github-pages` gem" turned out to be already done — the Gemfile has run plain `jekyll ~> 4.4` since the redesign. With this PR, all #199 follow-ups are complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Note: #205 also mentions restoring `@forward` and converting `@import` rules inside `assets/sass/` — neither applies: the original pre-workaround code (65163f9) never used `@forward`, and the partials contain no `@import` rules. This PR reverts exactly what the workaround changed.
