### PR TITLE
feat: news tag pills for website/software, placed inline with title

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -644,6 +644,14 @@ img {
     background: $qe-red;
     color: #fff;
   }
+  &--website {
+    background: #2a9d8f;
+    color: #fff;
+  }
+  &--software {
+    background: #9558b2;
+    color: #fff;
+  }
   &--tools {
     background: $qe-yellow;
     color: #333;
@@ -1358,7 +1366,8 @@ section {
   color: $color-dark;
   margin: 0 0 0.3rem 0;
   .qe-badge {
-    margin-left: 0.5rem;
+    display: inline-block;
+    margin: 0 0 0 0.5rem;
     vertical-align: middle;
   }
 }
@@ -1450,6 +1459,11 @@ section {
     font-size: 0.8rem;
     font-weight: normal;
     color: #999;
+  }
+  .qe-badge {
+    display: inline-block;
+    margin: 0 0 0 0.5rem;
+    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
Addresses #218 and #219 — both refine how the auto-drafted news-track tag pills render on the /news list.

## #218 — pill styling for `website` and `software`

The news track now emits four tags (`lectures`, `books`, `website`, `software`). `lectures` and `books` already had `.qe-badge--*` colour rules, but `website` and `software` fell through to the unstyled base `.qe-badge`, so they rendered as plain text. This adds two distinct colours so all four render consistently:

| Tag | Colour |
| --- | --- |
| lectures | `#306998` (blue, existing) |
| books | `#D25663` (red, existing) |
| website | `#2A9D8F` (teal, new) |
| software | `#9558B2` (purple, new) |

## #219 — pill inline with the title

The base `.qe-badge` is `display: block`, which pushed the pill onto its own line between the title and excerpt, adding vertical space on every entry. The news-card title and news-archive overrides now set `display: inline-block` so the pill sits next to the title — e.g. `Website update — June 8–14, 2026  [website]` on a single line — keeping each entry compact. Applied in both the recent-posts cards and the year archive list.

## Verification

`bundle exec jekyll build` succeeds. Temporary posts tagged `website` and `software` confirmed the layout emits `qe-badge--website` / `qe-badge--software` and that the pill renders on the same line as the title; the temp posts were removed before committing. The change is CSS-only (`assets/main.scss`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)