### PR TITLE
chore(deps): bump GitHub Pages actions (configure/upload/deploy)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build Jekyll site
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -38,7 +38,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     # Guard: only deploy from main, even when triggered via workflow_dispatch
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Combines the three open Dependabot bumps for the GitHub Pages deploy pipeline into a single merge, so the production deploy runs **once** with a matched action set rather than passing through three intermediate states. Closes #211, #212, #213.

## Changes — [.github/workflows/deploy.yml](.github/workflows/deploy.yml)

| Action | From | To | Nature of change |
| --- | --- | --- | --- |
| actions/configure-pages | 5 | 6 | Runtime only (Node 20 → 24) |
| actions/upload-pages-artifact | 3 | 5 | Internal `upload-artifact` → v7; adds `include-hidden-files` |
| actions/deploy-pages | 4 | 5 | Runtime only (Node 20 → 24) |

## Why combine rather than merge separately

`upload-pages-artifact` and `deploy-pages` are a coupled pair — the deploy job consumes the artifact the upload job produces — so they should move together. Merging the three Dependabot PRs one at a time would briefly leave `main` with a mixed action set on any deploy triggered in between, and would queue three production deploys. One PR avoids both.

## Breaking-change check

`upload-pages-artifact` v4+ excludes hidden files (dotfiles) from the Pages artifact. The built `_site` contains no dotfiles (no `.nojekyll`, no `.well-known`), so this has no effect here. The other two bumps are runtime-only.

Note: `deploy-pages@v5` runs only in the `deploy` job, which is gated to `main`, so it is exercised for the first time on the post-merge deploy (not by the PR `build` check). The `build` check does exercise `configure-pages@v6` and `upload-pages-artifact@v5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)