### PR TITLE
maint: bump Ruby 3.2 → 3.4, tidy jekyll-feed constraint

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ The QuantEcon website is a Jekyll-based static site that serves as the main port
 
 Install bundler and set up the development environment:
 - `gem install bundler --user-install` - Install bundler locally (required for Jekyll)
-- `export PATH="$HOME/.local/share/gem/ruby/3.2.0/bin:$PATH"` - Add bundler to PATH
+- `export PATH="$HOME/.local/share/gem/ruby/3.4.0/bin:$PATH"` - Add bundler to PATH
 - `bundle config set --local path 'vendor/bundle'` - Configure local gem installation path
 - `bundle install` - Install Jekyll dependencies (takes ~30 seconds)
 
@@ -82,9 +82,9 @@ Key directories and files:
 ## Dependencies and Requirements
 
 **Ruby Environment:**
-- Ruby 3.2+ (3.2.3 confirmed working)
+- Ruby 3.4+
 - Bundler gem manager
-- Jekyll 4.2.2 (specified in Gemfile)
+- Jekyll 4.4 (specified in Gemfile)
 
 **Key Jekyll plugins used:**
 - jekyll-feed - RSS feed generation
@@ -101,7 +101,7 @@ Key directories and files:
 - Never use `sudo` with gem commands
 
 **Build failures:**
-- Check that Ruby 3.2+ is installed
+- Check that Ruby 3.4+ is installed
 - Verify all dependencies installed with `bundle install`
 - Clear cache with `bundle exec jekyll clean` before rebuilding
 
@@ -133,7 +133,7 @@ Key directories and files:
 ```bash
 # Setup (run once after clone)
 gem install bundler --user-install
-export PATH="$HOME/.local/share/gem/ruby/3.2.0/bin:$PATH"
+export PATH="$HOME/.local/share/gem/ruby/3.4.0/bin:$PATH"
 bundle config set --local path 'vendor/bundle'
 bundle install
 
@@ -171,9 +171,9 @@ bundle exec jekyll build
 ### Key files content
 
 **Gemfile dependencies:**
-- jekyll ~> 4.2.2
+- jekyll ~> 4.4
 - minima ~> 2.5
-- jekyll-feed ~> 0.12
+- jekyll-feed ~> 0.17
 - jekyll-redirect-from
 - webrick ~> 1.8
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.4'
           bundler-cache: true
 
       - name: Build Jekyll site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.4'
           bundler-cache: true
 
       - name: Setup Pages

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ source "https://rubygems.org"
 gem "jekyll", "~> 4.4"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-feed", "~> 0.17"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   publish = "_site"
 
 [build.environment]
-  RUBY_VERSION = "3.2.2"
+  RUBY_VERSION = "3.4.1"
   BUNDLE_PATH = "vendor/bundle"
 
 # Deploy preview context (PRs)


### PR DESCRIPTION
Housekeeping from a version audit of the deploy setup. The audit found the **GitHub Actions and Jekyll are already current** — `actions/checkout@v7`, `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`, `ruby/setup-ruby@v1`, and Jekyll `~> 4.4` (4.4.1) are all on their latest releases. The only stale pieces were the Ruby version and one gem floor.

## Changes

| File | Before | After |
|---|---|---|
| `.github/workflows/deploy.yml` | `ruby-version: '3.2'` | `'3.4'` |
| `.github/workflows/build.yml` | `ruby-version: '3.2'` | `'3.4'` |
| `netlify.toml` | `RUBY_VERSION = "3.2.2"` | `"3.4.1"` |
| `Gemfile` | `jekyll-feed "~> 0.12"` | `"~> 0.17"` |

**Why:** Ruby 3.2 is at/past end-of-life for security fixes (latest is 4.0.x). Ruby 3.4 is the current, well-supported choice for Jekyll 4.4 — staying on the 3.x line avoids the unproven gem native-extension compatibility of jumping straight to 4.0. The `jekyll-feed` floor was stale at `~> 0.12`; 0.17.0 is current.

## Verification

`bundle exec jekyll build` succeeds locally with `jekyll-feed 0.17.0`. The PR preview (build.yml + Netlify) will confirm the Ruby 3.4 build on CI.

## Notes for the reviewer

- **This does not fix the ongoing production deploy outage.** That's a GitHub-side Pages backend failure (`Deployment failed, try again later`, fails in ~5s with a green build) unrelated to versions — the deploy action is already on the latest release. On merge, the production deploy step will keep failing until GitHub's backend recovers; the changes themselves are validated by the preview build.
- If Netlify's build image doesn't ship Ruby 3.4.1, the preview may need a Netlify-supported patch — the preview status on this PR will show it.
- `Gemfile.lock` is gitignored, so gem versions resolve fresh per build (not changed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)