### PR TITLE
Update John's bio: affiliation and research interests

### DIFF
--- a/_team-members/john.md
+++ b/_team-members/john.md
@@ -5,4 +5,4 @@ image: /assets/img/team/john.jpg
 link: http://johnstachurski.net/
 role: "Founding Members and Co-Chairs"
 ---
-John Stachurski is a Professor of Economics at Australian National University with interests in Markov process theory, asset pricing, dynamic programming and numerical methods.
+John Stachurski is a Professor of Economics at the National Graduate Institute for Policy Studies (GRIPS) with interests in optimization, statistics, and numerical methods.


### PR DESCRIPTION
## Summary
- Updates John Stachurski's affiliation from ANU to the National Graduate Institute for Policy Studies (GRIPS)
- Updates listed research interests to optimization, statistics, and numerical methods

This was briefly committed directly to `main` and has been reverted there; this PR re-applies it through review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)