### PR TITLE
Update About page: mission statement, sponsorship details, founding year

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -6,31 +6,58 @@ menu_item: false
 
 # About QuantEcon
 
-QuantEcon is a nonprofit organization dedicated to the development and documentation of open source computational tools for economics, econometrics, and decision making. We aim to make quantitative economic modeling accessible to researchers, students, and policymakers worldwide.
+## Mission Statement 
+
+QuantEcon advances open-source software and open science in economics. It
+provides freely available, high-quality computational tools and educational
+resources as a public good for the global economics community. QuantEcon is
+noncommercial, independent of any single institution, and committed
+to permanent open licensing.
+
+Legally, QuantEcon is a fiscally sponsored project of 
+[NumFOCUS](http://www.numfocus.org/) and [PSL Foundation](https://psl-foundation.org/).
+While QuantEcon is not an independent 501(c)(3), it can, for most
+purposes, be treated as one. Donations are tax-deductible, received on its
+behalf by the sponsors, which are themselves 501(c)(3) nonprofits. The sponsors
+are QuantEcon's legal and financial home: they hold its funds and act on its
+behalf — for example, NumFOCUS holds and protects the QuantEcon trademark.
+QuantEcon keeps its own name, governance, and editorial control, and operates
+under its sponsors' tax-exempt status rather than maintaining a legal entity of
+its own.
+
 
 ## What We Do
 
-* **Lectures** — We develop and maintain world-leading [lecture series](/lectures/) on economics, finance, econometrics, and data science, all based on open source languages and computing environments.
+* **Lectures** — We develop and maintain high quality [lecture
+  series](/lectures/) on economics, finance, econometrics, and data science, all
+  based on open source languages and computing environments.
 
-* **Books** — We publish open access [textbooks](/books/) on dynamic programming, economic networks, and quantitative macroeconomic finance.
+* **Books** — We publish open access [textbooks](/books/) on quantitative economics and finance.
 
-* **Code Libraries** — We develop and maintain high-performance, open source [code libraries](/code/) in Python and Julia for quantitative economic modeling.
+* **Code Libraries** — We develop and maintain high-performance, open source
+  [code libraries](/code/) in Python and Julia for quantitative economic
+  modeling.
 
-* **Workshops** — We run remote and in-person [workshops](/workshops/) at leading universities, central banks, and international organizations around the world.
+* **Workshops** — We run remote and in-person [workshops](/workshops/) at
+  leading universities, central banks, and international organizations around
+  the world.
 
-* **Infrastructure** — We build open source [tools and infrastructure](/infrastructure/) for computational education, including contributions to Jupyter Book and the Executable Books Project.
+* **Infrastructure** — We build open source [tools and infrastructure](/infrastructure/) for computational education, including
+  contributions to Jupyter Book and the Executable Books Project.
 
 ## History
 
-QuantEcon was co-founded by [Thomas J. Sargent](http://www.tomsargent.com/) (Nobel Laureate, New York University) and [John Stachurski](https://johnstachurski.net/) (Australian National University). The organization brings together economists, mathematicians, and developers to coordinate the development of high-quality computational tools for the economics community.
+QuantEcon was co-founded in 2015 by [Thomas J.
+Sargent](http://www.tomsargent.com/) (Nobel Laureate, New York University) and
+[John Stachurski](https://johnstachurski.net/) (Australian National University).
 
-## Affiliations
-
-QuantEcon is a [NumFOCUS](http://www.numfocus.org/) and [PSL Foundation](https://psl-foundation.org/) Fiscally Sponsored Project.
 
 ## Get Involved
 
-We welcome contributions to our lecture series, code libraries, and infrastructure projects. Visit our [GitHub organization](https://github.com/QuantEcon/) to explore our repositories and find ways to contribute.
+We welcome contributions to our lecture series, code libraries, and
+infrastructure projects. Visit our [GitHub
+organization](https://github.com/QuantEcon/) to explore our repositories and
+find ways to contribute.
 
 ## Contact
 


### PR DESCRIPTION
## Summary
- Add a mission statement section explaining QuantEcon's role and open-source/open-science commitment
- Clarify QuantEcon's fiscal sponsorship arrangement with NumFOCUS and PSL Foundation (tax status, trademark holding, governance)
- Add founding year (2015) to the History section and minor copy tweaks elsewhere

## Test plan
- [x] Preview rendered about page to confirm markdown formatting/links are correct